### PR TITLE
Remove reference to rt.cpan.org as bugtracker

### DIFF
--- a/lib/Pod/Weaver/PluginBundle/SHLOMIF.pm
+++ b/lib/Pod/Weaver/PluginBundle/SHLOMIF.pm
@@ -63,8 +63,12 @@ sub mvp_bundle_config {
             '@SHLOMIF/Support',
             _exp('Support'),
             {
-                all_modules => 1,
-                perldoc     => 0,
+                all_modules  => 1,
+                bugs         => 'metadata',
+                bugs_content => $bugtracker_content,
+                perldoc      => 0,
+                websites     => ["deps", "kwalitee", "metacpan",
+                                         "testers" , "testmatrix"],
             }
         ],
         [ '@SHLOMIF/Authors',      _exp('Authors'),      {} ],


### PR DESCRIPTION
According to [this](https://perlhacks.com/2020/12/rt-action-plan-for-cpan-authors/) blog rt.cpan.org will sunset in March 2021.

[I was assigned Dir::Manifest by [pullrequest.club](https://pullrequest.club). This fix should fix the Pod in that distribution also.]